### PR TITLE
Add AD auth for login

### DIFF
--- a/Models/Options/ADSettings.cs
+++ b/Models/Options/ADSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace SenseNetAuth.Models.Options;
+
+public class ADSettings
+{
+    public string Enabled { get; set; } = string.Empty;
+    public string Domain { get; set; } = string.Empty;
+}

--- a/Program.cs
+++ b/Program.cs
@@ -24,6 +24,7 @@ public class Program
             .Configure<PasswordRecoverySettings>(options => builder.Configuration.GetSection("PasswordRecovery").Bind(options))
             .Configure<EmailSettings>(options => builder.Configuration.GetSection("Email").Bind(options))
             .Configure<RecaptchaSettings>(options => builder.Configuration.GetSection("Recaptcha").Bind(options))
+            .Configure<ADSettings>(options => builder.Configuration.GetSection("ADSetting").Bind(options))
             .AddSenseNetClient()
             .ConfigureSenseNetRepository(Repositories.Default, repositoryOptions =>
             {

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -16,11 +16,11 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
 
         "Sensenet__Repository__Url": "https://localhost:44362",
-        "Sensenet__Repository__Authentication__ApiKey": "--to-be-set--",
+        "Sensenet__Repository__Authentication__ApiKey": "",
 
         "JwtSettings__Issuer": "https://localhost:44362",
         "JwtSettings__Audience": "sensenet",
-        "JwtSettings__SecretKey": "--to-be-set--",
+        "JwtSettings__SecretKey": "",
         "JwtSettings__AuthTokenExpiryMinutes": "300",
         "JwtSettings__MultiFactorAuthExpiryMinutes": "300",
         "JwtSettings__TokenExpiryMinutes": "300",
@@ -30,8 +30,8 @@
 
         "Registration__IsEnabled": "false",
 
-        "Recaptcha__SiteKey": "--to-be-set--",
-        "Recaptcha__SecretKey": "--to-be-set--",
+        "Recaptcha__SiteKey": "",
+        "Recaptcha__SecretKey": "",
 
         "Application__Url": "https://localhost:44311",
         "Application__AllowedHosts__0": "https://adminui.test.sensenet.com",
@@ -60,11 +60,11 @@
 
         "Sensenet__Repository__Url": "https://localhost:44362",
         "Sensenet__Repository__InnerUrl": "http://SnWebApplication",
-        "Sensenet__Repository__Authentication__ApiKey": "--to-be-set--",
+        "Sensenet__Repository__Authentication__ApiKey": "",
 
         "JwtSettings__Issuer": "https://localhost:44362",
         "JwtSettings__Audience": "sensenet",
-        "JwtSettings__SecretKey": "--to-be-set--",
+        "JwtSettings__SecretKey": "",
         "JwtSettings__AuthTokenExpiryMinutes": "300",
         "JwtSettings__MultiFactorAuthExpiryMinutes": "300",
         "JwtSettings__TokenExpiryMinutes": "300",
@@ -74,8 +74,8 @@
 
         "Registration__IsEnabled": "false",
 
-        "Recaptcha__SiteKey": "--to-be-set--",
-        "Recaptcha__SecretKey": "--to-be-set--",
+        "Recaptcha__SiteKey": "",
+        "Recaptcha__SecretKey": "",
 
         "Application__Url": "https://localhost:44311",
         "Application__AllowedHosts__0": "https://adminui.test.sensenet.com",

--- a/SenseNetAuth.csproj
+++ b/SenseNetAuth.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="9.0.8" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
   </ItemGroup>
 

--- a/Services/AuthService.cs
+++ b/Services/AuthService.cs
@@ -1,11 +1,11 @@
-﻿using System.Text.RegularExpressions;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 using SenseNetAuth.Infrastructure.Exceptions;
 using SenseNetAuth.Models;
 using SenseNetAuth.Models.Constants;
 using SenseNetAuth.Models.Options;
 using SenseNetAuth.TokenProviders;
 using SenseNetAuth.TokenProviders.InMemory;
+using System.Text.RegularExpressions;
 
 namespace SenseNetAuth.Services;
 

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -46,14 +46,19 @@ namespace SenseNetAuth.Services
             string adDomain = _adsettingsOptions.Domain.ToLower();
             if (!string.IsNullOrWhiteSpace(username) && adEnabled && !string.IsNullOrEmpty(adDomain) && username.ToLower().StartsWith(adDomain + "\\"))
             {
-                var userHelper = username;
-                if (!username.Contains("\\")) {
-                    userHelper = adDomain + "\\" + username;
+                var userOnlyName = username;
+                var userADAuthHelper = username;
+                if (username.Contains("\\")) {
+                    userOnlyName = username.Split('\\')[1];
+                }
+                else
+                {
+                    userADAuthHelper = adDomain + "\\" + username;
                 }
                 
                 var query = new QueryContentRequest
                 {
-                    ContentQuery = $"+InTree:'/Root/IMS' +TypeIs:User +LoginName:{userHelper}",
+                    ContentQuery = $"+InTree:'/Root/IMS' +TypeIs:User +LoginName:{userOnlyName} +Domain:{adDomain}",
                 };
                 var results = await repo.QueryAsync<User>(query, cancel).ConfigureAwait(false);
 
@@ -62,7 +67,7 @@ namespace SenseNetAuth.Services
                     try
                     {
                         User queriedUser = results.First();
-                        bool isADAuth = await ActiveDirectoryAuthentication(userHelper, password);
+                        bool isADAuth = await ActiveDirectoryAuthentication(userADAuthHelper, password);
                         if (isADAuth)
                         {
                             return queriedUser.Id;

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -3,6 +3,7 @@ using SenseNet.Client;
 using SenseNetAuth.Models;
 using SenseNetAuth.Models.Constants;
 using SenseNetAuth.Models.Options;
+using System.DirectoryServices.AccountManagement;
 
 namespace SenseNetAuth.Services
 {
@@ -10,14 +11,17 @@ namespace SenseNetAuth.Services
     {
         private readonly IRepositoryCollection _repositoryCollection;
         private readonly RegistrationSettings _registrationSettings;
+        private readonly ADSettings _adsettingsOptions;
 
         public UserService(
             IRepositoryCollection repositoryCollection,
-            IOptions<RegistrationSettings> options
+            IOptions<RegistrationSettings> registrationOptions,
+            IOptions<ADSettings> adsettingsOptions
         )
         {
             _repositoryCollection = repositoryCollection;
-            _registrationSettings = options.Value;
+            _registrationSettings = registrationOptions.Value;
+            _adsettingsOptions = adsettingsOptions.Value;
         }
 
         public async Task<User?> GetUserByUserIdAsync(int userId, CancellationToken cancel)
@@ -38,27 +42,64 @@ namespace SenseNetAuth.Services
         {
             var repo = await GetRepositoryAsync(cancel);
 
-            var request = new OperationRequest
+            bool adEnabled = _adsettingsOptions.Enabled.ToLower() == "true";
+            string adDomain = _adsettingsOptions.Domain;
+            if (adEnabled && !string.IsNullOrEmpty(adDomain) && username.StartsWith(adDomain + "\\"))
             {
-                OperationName = "ValidateCredentials",
-                Path = "/Root",
-                PostData = new
-                {
-                    username,
-                    password
+                var userHelper = username;
+                if (!username.Contains("\\")) {
+                    userHelper = adDomain + "\\" + username;
                 }
-            };
+                
+                var query = new QueryContentRequest
+                {
+                    ContentQuery = $"+InTree:/Root/IMS +TypeIs:User +LoginName: {userHelper}",
+                };
+                var results = await repo.QueryAsync<User>(query, cancel).ConfigureAwait(false);
 
-            try
+                if (results != null && results.Count() > 0)
+                {
+                    try
+                    {
+                        User queriedUser = results.First();
+                        bool isADAuth = await ActiveDirectoryAuthentication(userHelper, password);
+                        if (isADAuth)
+                        {
+                            return queriedUser.Id;
+                        }
+                    }
+                    catch(Exception ex)
+                    {
+                        return null;
+                    }
+                }
+            }
+            else
             {
-                var response = await repo.InvokeActionAsync<dynamic>(request, cancel);
+                var request = new OperationRequest
+                {
+                    OperationName = "ValidateCredentials",
+                    Path = "/Root",
+                    PostData = new
+                    {
+                        username,
+                        password
+                    }
+                };
 
-                return response.id;
+                try
+                {
+                    var response = await repo.InvokeActionAsync<dynamic>(request, cancel);
+
+                    return response.id;
+                }
+                catch
+                {
+                    return null;
+                }
             }
-            catch
-            {
-                return null;
-            }
+
+            return null;
         }
 
         public async Task<MultiFactorInfoResponse?> GetMultiFactorAuthenticationInfoAsync(int userId, CancellationToken cancel)
@@ -153,12 +194,24 @@ namespace SenseNetAuth.Services
             return false;
         }
 
+        private Task<bool> ActiveDirectoryAuthentication(string username, string password)
+        {
+            bool resultBool = false;
+
+            using (PrincipalContext principalContext = new(ContextType.Domain))
+            {
+                resultBool = principalContext.ValidateCredentials(username, password);
+            }
+
+            return Task.FromResult(resultBool);
+        }
+
         private async Task<User?> GetUserByUserIdAsync(IRepository repo, int userId, CancellationToken cancel)
         {
-            var query = new QueryContentRequest
-            {
-                ContentQuery = $"Id: {userId}",
-            };
+            //var query = new QueryContentRequest
+            //{
+            //    ContentQuery = $"Id: {userId}",
+            //};
             var results = await repo.LoadContentAsync<User>(userId, cancel)
                 .ConfigureAwait(false);
 

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -43,8 +43,8 @@ namespace SenseNetAuth.Services
             var repo = await GetRepositoryAsync(cancel);
 
             bool adEnabled = _adsettingsOptions.Enabled.ToLower() == "true";
-            string adDomain = _adsettingsOptions.Domain;
-            if (adEnabled && !string.IsNullOrEmpty(adDomain) && username.StartsWith(adDomain + "\\"))
+            string adDomain = _adsettingsOptions.Domain.ToLower();
+            if (!string.IsNullOrWhiteSpace(username) && adEnabled && !string.IsNullOrEmpty(adDomain) && username.ToLower().StartsWith(adDomain + "\\"))
             {
                 var userHelper = username;
                 if (!username.Contains("\\")) {
@@ -53,7 +53,7 @@ namespace SenseNetAuth.Services
                 
                 var query = new QueryContentRequest
                 {
-                    ContentQuery = $"+InTree:/Root/IMS +TypeIs:User +LoginName: {userHelper}",
+                    ContentQuery = $"+InTree:'/Root/IMS' +TypeIs:User +LoginName:{userHelper}",
                 };
                 var results = await repo.QueryAsync<User>(query, cancel).ConfigureAwait(false);
 
@@ -90,7 +90,6 @@ namespace SenseNetAuth.Services
                 try
                 {
                     var response = await repo.InvokeActionAsync<dynamic>(request, cancel);
-
                     return response.id;
                 }
                 catch

--- a/appsettings.json
+++ b/appsettings.json
@@ -14,7 +14,7 @@
   "JwtSettings": {
     "Issuer": "",
     "Audience": "sensenet",
-    "SecretKey": "-here-comes-the-secret-key-",
+    "SecretKey": "",
     "AuthTokenExpiryMinutes": 300,
     "MultiFactorAuthExpiryMinutes": 300,
     "TokenExpiryMinutes": 300,
@@ -34,16 +34,20 @@
     "MainUserPath": ""
   },
   "Recaptcha": {
-    "SiteKey": "-here-comes-the-site-key-",
-    "SecretKey": "-here-comes-the-secret-key-"
+    "SiteKey": "",
+    "SecretKey": ""
   },
   "Sensenet": {
     "Repository": {
       "Url": "",
       "InnerUrl": "",
       "Authentication": {
-        "ApiKey": "-here-comes-the-api-key-"
+        "ApiKey": ""
       }
     }
+  },
+  "ADSetting": {
+    "Enabled": true,
+    "Domain": "sn"
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -47,7 +47,7 @@
     }
   },
   "ADSetting": {
-    "Enabled": true,
+    "Enabled": false,
     "Domain": "sn"
   }
 }


### PR DESCRIPTION
Add AD validation for login# Add Active Directory Authentication Support

## Summary
This PR implements Active Directory (AD) authentication for user login, allowing users to authenticate against an AD domain in addition to the existing SenseNet authentication mechanism.

## Changes Made

### Core Features
- **Active Directory Authentication**: Added support for authenticating users against an AD domain using `System.DirectoryServices.AccountManagement`
- **Hybrid Authentication**: Maintains backward compatibility with existing SenseNet authentication while adding AD support
- **Domain-based User Resolution**: Queries SenseNet for users with matching LoginName and Domain when AD is enabled

### New Files
- `Models/Options/ADSettings.cs`: Configuration model for AD settings (Enabled, Domain)

### Modified Files
- `Program.cs`: Added AD settings configuration binding
- `SenseNetAuth.csproj`: Added `System.DirectoryServices.AccountManagement` package reference
- `Services/UserService.cs`: 
  - Integrated AD authentication logic in `ValidateCredentialsAsync`
  - Added `ActiveDirectoryAuthentication` helper method
  - Enhanced user lookup to support domain-based queries
- `appsettings.json`: Added ADSetting configuration section
- `Properties/launchSettings.json`: Updated environment variables (removed placeholder values)

### Authentication Flow
1. Check if AD authentication is enabled and user matches domain pattern
2. Extract username from domain\username format
3. Query SenseNet for user with matching LoginName and Domain
4. Validate credentials against AD using PrincipalContext
5. Fall back to standard SenseNet authentication if AD is disabled or user doesn't match domain

### Configuration
```json
"ADSetting": {
  "Enabled": "false",
  "Domain": "sn"
}