### PR TITLE
feat(ci, email): configurable SMTP SSL and Docker image build/push workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,80 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches:
+      - 'develop'
+      - 'main'
+      - 'master'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 'develop'
+      - 'main'
+      - 'master'
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: 'Push the built image to DockerHub'
+        required: false
+        default: false
+        type: boolean
+      custom_tag:
+        description: "Optional extra tag (e.g. 'test-xyz'). Branch name is always tagged."
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Skip draft PRs
+    if: github.event.pull_request.draft == false || github.event_name == 'push'
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Check if Dockerfile exists
+        id: check_dockerfile
+        run: |
+          if [ -f "src/sn-auth/Dockerfile" ]; then
+            echo "dockerfile_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "dockerfile_exists=false" >> $GITHUB_OUTPUT
+            echo "⚠️ No Dockerfile found, skipping Docker build"
+          fi
+
+      - name: Set up Docker metadata
+        if: steps.check_dockerfile.outputs.dockerfile_exists == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: sensenetcsp/sn-snauth
+          tags: |
+            # Clean branch name (e.g., feature-conditional-recaptcha)
+            type=ref,event=branch
+            # 'latest' tag only when pushing to main or master (regardless of default branch)
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
+            # 'preview' tag only when pushing to develop
+            type=raw,value=preview,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+            # PR number for pull requests
+            type=ref,event=pr
+            # Optional custom tag from manual workflow_dispatch
+            type=raw,value=${{ inputs.custom_tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.custom_tag != '' }}
+
+      - name: Login to DockerHub
+        if: steps.check_dockerfile.outputs.dockerfile_exists == 'true' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push_image))
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        if: steps.check_dockerfile.outputs.dockerfile_exists == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/sn-auth/Dockerfile
+          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push_image) }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,7 +49,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: sensenetcsp/sn-snauth
+          images: sensenetcsp/sn-auth
           tags: |
             # Clean branch name (e.g., feature-conditional-recaptcha)
             type=ref,event=branch

--- a/src/sn-auth/Models/Options/EmailSettings.cs
+++ b/src/sn-auth/Models/Options/EmailSettings.cs
@@ -8,4 +8,5 @@ public class EmailSettings
     public string Password { get; set; } = string.Empty;
     public string FromEmail { get; set; } = string.Empty;
     public string FromName { get; set; } = string.Empty;
+    public bool EnableSsl { get; set; } = true;
 }

--- a/src/sn-auth/Services/EmailService.cs
+++ b/src/sn-auth/Services/EmailService.cs
@@ -37,7 +37,7 @@ public class EmailService : IEmailService
         using var client = new SmtpClient(_emailSettings.Server, _emailSettings.Port);
         if (!string.IsNullOrEmpty(_emailSettings.Username) && !string.IsNullOrEmpty(_emailSettings.Password))
             client.Credentials = new NetworkCredential(_emailSettings.Username, _emailSettings.Password);
-        client.EnableSsl = true;
+        client.EnableSsl = _emailSettings.EnableSsl;
 
         var mailMessage = new MailMessage
         {

--- a/src/sn-auth/appsettings.json
+++ b/src/sn-auth/appsettings.json
@@ -27,7 +27,8 @@
     "Server": "",
     "Port": 0,
     "FromEmail": "",
-    "FromName": ""
+    "FromName": "",
+    "EnableSsl": true
   },
   "Registration": {
     "IsEnabled": false,


### PR DESCRIPTION
## Summary

This PR introduces two independent changes:

1. **Configurable SMTP SSL** — the `EnableSsl` flag on `SmtpClient` is now driven by configuration instead of being hard-coded, so deployments that target SMTP servers without TLS (e.g. internal relays) can opt out.
2. **Docker image CI workflow** — adds a GitHub Actions workflow that builds and publishes the application's Docker image to Docker Hub (`sensenetcsp/sn-auth`) on pushes to the main branches, validates the build on pull requests, and exposes a manual trigger for ad-hoc builds from any branch.

## Changes

### Email / SMTP
- `EmailSettings.EnableSsl` (bool, default `true`) added.
- `EmailService` now reads `EnableSsl` from `EmailSettings` instead of hard-coding `true`.
- `appsettings.json` extended with the new `EnableSsl` key (default `true`, preserves existing behavior).

### CI / Docker
- New workflow: `.github/workflows/docker-image.yml`.
- Triggers:
  - `push` to `develop`, `main`, `master` → build **and push** image.
  - `pull_request` (non-draft) targeting `develop`, `main`, `master` → build only (validation, no push).
  - `workflow_dispatch` → manual run from any branch, with optional `push_image` and `custom_tag` inputs.
- Tagging strategy (via `docker/metadata-action`):
  - `:<branch-name>` for any push or PR build.
  - `:latest` only when pushing to `main` or `master` (independent of which branch is set as default in GitHub).
  - `:preview` only when pushing to `develop`.
  - `:pr-<number>` for pull request builds.
  - `:<custom_tag>` when supplied via manual dispatch.
- Build context is the repository root; Dockerfile path is `src/sn-auth/Dockerfile`.
- DockerHub login uses the existing organization secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`, and only runs when an actual push is going to happen.

## Behavior notes

- `EnableSsl` defaults to `true`, so existing deployments are unaffected unless they explicitly opt out.
- The `Run workflow` button (manual dispatch) only becomes visible in the GitHub Actions UI **after** this workflow lands on the default branch.

## Testing

- PR build will execute the workflow against this branch via the `pull_request` trigger, validating that the Docker image builds end-to-end without pushing to the registry.
- SMTP change is config-only and preserves the previous default behavior.