### PR TITLE
feat: add configurable X-Tags header for email tagging in Mailpit

### DIFF
--- a/src/sn-auth/Models/Options/EmailSettings.cs
+++ b/src/sn-auth/Models/Options/EmailSettings.cs
@@ -9,4 +9,5 @@ public class EmailSettings
     public string FromEmail { get; set; } = string.Empty;
     public string FromName { get; set; } = string.Empty;
     public bool EnableSsl { get; set; } = true;
+    public string Tag { get; set; } = string.Empty;
 }

--- a/src/sn-auth/Services/EmailService.cs
+++ b/src/sn-auth/Services/EmailService.cs
@@ -47,6 +47,9 @@ public class EmailService : IEmailService
             IsBodyHtml = true
         };
 
+        if (!string.IsNullOrEmpty(_emailSettings.Tag))
+            mailMessage.Headers.Add("X-Tags", _emailSettings.Tag);
+
         mailMessage.To.Add(toEmail);
 
         try

--- a/src/sn-auth/appsettings.json
+++ b/src/sn-auth/appsettings.json
@@ -28,7 +28,8 @@
     "Port": 0,
     "FromEmail": "",
     "FromName": "",
-    "EnableSsl": true
+    "EnableSsl": true,
+    "Tag": ""
   },
   "Registration": {
     "IsEnabled": false,


### PR DESCRIPTION
- Add Tag property to EmailSettings (default: empty)
- Inject X-Tags header into MailMessage if Tag is configured
- Update appsettings.json with Tag field
- Allows tagging emails by application source in Mailpit UI
- Environment variable override: Email__Tag=sn-auth (or multiple tags with comma separator)